### PR TITLE
Removing the "$" char of copyable shell commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Laravel Reactions is the package you need if you want to implement reactions for
 Install the package with Composer.
 
 ``` bash
-$ composer require DevDojo/laravel-reactions
+composer require DevDojo/laravel-reactions
 ```
 
 Add the Service Provider to your `config/app.php` file.
@@ -38,7 +38,7 @@ DevDojo\LaravelReactions\Providers\ReactionsServiceProvider::class,
 Run the migrations to create `reactions` and `reactables` tables.
 
 ```bash
-$ php artisan migrate
+php artisan migrate
 ```
 
 You're good to go.
@@ -191,7 +191,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Testing
 
 ``` bash
-$ vendor/bin/phpunit
+vendor/bin/phpunit
 ```
 
 ## Contributing


### PR DESCRIPTION
## Description

Removing the "$" char of copyable shell commands in README.md

## Motivation and context

Well, always when I'm just copying the text for composer install it copies the starting $ char which gives an error when pasting in the terminal, the change just removes the initial $ char.

## How has this been tested?

It's just a README fix, so just copied and paste to ensure it was ok.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
